### PR TITLE
chore: added sqlc to devcontainer

### DIFF
--- a/.github/.devcontainer/devcontainer.json
+++ b/.github/.devcontainer/devcontainer.json
@@ -17,6 +17,7 @@
 		},
 		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
 		"ghcr.io/devcontainers/features/kubectl-helm-minikube:1":{},
-		"ghcr.io/devcontainers-contrib/features/caddy:1":{}
+		"ghcr.io/devcontainers-contrib/features/caddy:1":{},
+		"ghcr.io/nucleuscloud/devcontainer-features/sqlc:1":{}
 	}
 }


### PR DESCRIPTION
This PR adds sqlc to the devcontainer. This lays the foundation for the upcoming migration off of leg100's pggen fork, and onto sqlc.