### PR TITLE
chore: upgraded to go1.22 router; fixed breaking changes

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@a4f60bb28d35aeee14e6880718e0c85ff1882e64 # v6.0.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tofutf/tofutf
 
-go 1.21
+go 1.22
 
 require (
 	cloud.google.com/go/pubsub v1.37.0

--- a/internal/gitlab/client.go
+++ b/internal/gitlab/client.go
@@ -146,7 +146,7 @@ func (g *Client) GetRepoTarball(ctx context.Context, opts vcs.GetRepoTarballOpti
 		SHA:    opts.Ref,
 	})
 	if err != nil {
-		return nil, "", err
+		return nil, "", fmt.Errorf("gitlab client failed to retrieve archive: %w", err)
 	}
 
 	// Gitlab tarball contents are contained within a top-level directory

--- a/internal/gitlab/client_test.go
+++ b/internal/gitlab/client_test.go
@@ -18,8 +18,7 @@ import (
 func TestClient_GetUser(t *testing.T) {
 	mux, client := setup(t)
 
-	mux.HandleFunc("/api/v4/user", func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "GET", r.Method)
+	mux.HandleFunc("GET /api/v4/user", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, `{"username":"bobby"}`)
 	})
 
@@ -32,8 +31,10 @@ func TestClient_GetUser(t *testing.T) {
 func TestClient_GetRepository(t *testing.T) {
 	mux, client := setup(t)
 
-	mux.HandleFunc("/api/v4/projects/acme/terraform", func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "GET", r.Method)
+	mux.HandleFunc("GET /api/v4/projects/{path_with_namespace}", func(w http.ResponseWriter, r *http.Request) {
+		pathWithNamespace := r.PathValue("path_with_namespace")
+		require.Equal(t, pathWithNamespace, "acme/terraform")
+
 		fmt.Fprint(w, `{"path_with_namespace":"acme/terraform","default_branch":"master"}`)
 	})
 
@@ -47,8 +48,7 @@ func TestClient_GetRepository(t *testing.T) {
 func TestClient_ListRepositories(t *testing.T) {
 	mux, client := setup(t)
 
-	mux.HandleFunc("/api/v4/projects", func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "GET", r.Method)
+	mux.HandleFunc("GET /api/v4/projects", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, `[{"path_with_namespace":"acme/terraform"}]`)
 	})
 
@@ -61,8 +61,10 @@ func TestClient_ListRepositories(t *testing.T) {
 func TestClient_GetRepoTarball(t *testing.T) {
 	mux, client := setup(t)
 
-	mux.HandleFunc("/api/v4/projects/acme/terraform/repository/archive.tar.gz", func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "GET", r.Method)
+	mux.HandleFunc("GET /api/v4/projects/{path_with_namespace}/repository/archive.tar.gz", func(w http.ResponseWriter, r *http.Request) {
+		pathWithNamespace := r.PathValue("path_with_namespace")
+		require.Equal(t, pathWithNamespace, "acme/terraform")
+
 		w.Write(testutils.ReadFile(t, "../testdata/gitlab.tar.gz")) //nolint:errcheck
 	})
 
@@ -82,7 +84,7 @@ func TestClient_GetRepoTarball(t *testing.T) {
 func TestClient_GetRepoTarballSubGroup(t *testing.T) {
 	mux, client := setup(t)
 
-	mux.HandleFunc("/api/v4/projects/acme/subgroup/terraform/repository/archive.tar.gz", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("GET /api/v4/projects/{path_with_subgroup_and_namespace}/repository/archive.tar.gz", func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "GET", r.Method)
 		w.Write(testutils.ReadFile(t, "../testdata/gitlab.tar.gz")) //nolint:errcheck
 	})
@@ -103,8 +105,10 @@ func TestClient_GetRepoTarballSubGroup(t *testing.T) {
 func TestClient_CreateWebhook(t *testing.T) {
 	mux, client := setup(t)
 
-	mux.HandleFunc("/api/v4/projects/acme/terraform/hooks", func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "POST", r.Method)
+	mux.HandleFunc("POST /api/v4/projects/{path_with_namespace}/hooks", func(w http.ResponseWriter, r *http.Request) {
+		pathWithNamespace := r.PathValue("path_with_namespace")
+		require.Equal(t, pathWithNamespace, "acme/terraform")
+
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
@@ -118,8 +122,10 @@ func TestClient_CreateWebhook(t *testing.T) {
 func TestClient_UpdateWebhook(t *testing.T) {
 	mux, client := setup(t)
 
-	mux.HandleFunc("/api/v4/projects/acme/terraform/hooks/1", func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "PUT", r.Method)
+	mux.HandleFunc("PUT /api/v4/projects/{path_with_namespace}/hooks/1", func(w http.ResponseWriter, r *http.Request) {
+		pathWithNamespace := r.PathValue("path_with_namespace")
+		require.Equal(t, pathWithNamespace, "acme/terraform")
+
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
@@ -132,8 +138,10 @@ func TestClient_UpdateWebhook(t *testing.T) {
 func TestClient_GetWebhook(t *testing.T) {
 	mux, client := setup(t)
 
-	mux.HandleFunc("/api/v4/projects/acme/terraform/hooks/1", func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "GET", r.Method)
+	mux.HandleFunc("GET /api/v4/projects/{path_with_namespace}/hooks/1", func(w http.ResponseWriter, r *http.Request) {
+		pathWithNamespace := r.PathValue("path_with_namespace")
+		require.Equal(t, pathWithNamespace, "acme/terraform")
+
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
@@ -147,8 +155,10 @@ func TestClient_GetWebhook(t *testing.T) {
 func TestClient_DeleteWebhook(t *testing.T) {
 	mux, client := setup(t)
 
-	mux.HandleFunc("/api/v4/projects/acme/terraform/hooks/1", func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "DELETE", r.Method)
+	mux.HandleFunc("DELETE /api/v4/projects/{path_with_namespace}/hooks/1", func(w http.ResponseWriter, r *http.Request) {
+		pathWithNamespace := r.PathValue("path_with_namespace")
+		require.Equal(t, pathWithNamespace, "acme/terraform")
+
 		fmt.Fprint(w, `{"id":1}`)
 	})
 
@@ -162,8 +172,10 @@ func TestClient_DeleteWebhook(t *testing.T) {
 func TestClient_ListPullRequestFiles(t *testing.T) {
 	mux, client := setup(t)
 
-	mux.HandleFunc("/api/v4/projects/acme/terraform/merge_requests/1/diffs", func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "GET", r.Method)
+	mux.HandleFunc("GET /api/v4/projects/{path_with_namespace}/merge_requests/1/diffs", func(w http.ResponseWriter, r *http.Request) {
+		pathWithNamespace := r.PathValue("path_with_namespace")
+		require.Equal(t, pathWithNamespace, "acme/terraform")
+
 		fmt.Fprint(w, `[{"old_path":"main.tf","new_path":"main.tf"},{"old_path":"dev.tf","new_path":"prod.tf"}]`)
 	})
 
@@ -175,8 +187,10 @@ func TestClient_ListPullRequestFiles(t *testing.T) {
 func TestClient_GetCommit(t *testing.T) {
 	mux, client := setup(t)
 
-	mux.HandleFunc("/api/v4/projects/acme/terraform/repository/commits/abc123", func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "GET", r.Method)
+	mux.HandleFunc("GET /api/v4/projects/{path_with_namespace}/repository/commits/abc123", func(w http.ResponseWriter, r *http.Request) {
+		pathWithNamespace := r.PathValue("path_with_namespace")
+		require.Equal(t, pathWithNamespace, "acme/terraform")
+
 		fmt.Fprint(w, `{"id":"abc123","web_url":"https://gitlab.com/commits/abc123"}`)
 	})
 


### PR DESCRIPTION
Go 1.22 introduces some breaking changes to how routing functions. This PR makes the upgrade to the new router (by specifying go 1.22 in go.mod), and then fixing the tests that were broken as a result. 