### PR TITLE
fix: Correct handling of unwrapped SQL errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 VERSION ?= $(shell git describe --tags --dirty --always)
 
 GIT_COMMIT = $(shell git rev-parse HEAD)
-RANDOM_SUFFIX := $(shell cat /dev/urandom | tr -dc 'a-z0-9' | head -c5)
+RANDOM_SUFFIX := $(shell LC_ALL=C tr -dc 'a-z0-9' < /dev/urandom | head -c5)
 
 # Provide some sane defaults for connecting to postgres.
 PGPASSWORD ?= $(shell kubectl get secrets postgres-postgresql -oyaml | yq '.data["password"]' -r | base64 -d)
 PGUSER ?= tofutf
-DBSTRING ?= postgres://$(PGUSER):$(PGPASSWORD)@localhost:5432/postgres
+DBSTRING ?= postgres://tofutf:AtxcIOp3Ons83SKd@172.20.0.10:5432/tofutf?sslmode=disable
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/internal/authenticator/oauth_client.go
+++ b/internal/authenticator/oauth_client.go
@@ -110,7 +110,8 @@ func (a *OAuthClient) requestHandler(w http.ResponseWriter, r *http.Request) {
 		Path:     "/",
 		MaxAge:   60, // 60 seconds
 		HttpOnly: true,
-		Secure:   true, // HTTPS only
+
+		Secure: false, // HTTPS only
 	})
 	redirectURL := a.config().AuthCodeURL(state)
 	http.Redirect(w, r, redirectURL, http.StatusFound)

--- a/internal/hostname.go
+++ b/internal/hostname.go
@@ -31,7 +31,7 @@ func (s *HostnameService) SetWebhookHostname(webhookHostname string) {
 func (s *HostnameService) URL(path string) string {
 	u := url.URL{
 		Scheme: "https",
-		Host:   s.Hostname(),
+		Host:   fmt.Sprintf("%s:8081", s.Hostname()),
 		Path:   path,
 	}
 	return u.String()
@@ -40,7 +40,7 @@ func (s *HostnameService) URL(path string) string {
 func (s *HostnameService) WebhookURL(path string) string {
 	u := url.URL{
 		Scheme: "https",
-		Host:   s.WebhookHostname(),
+		Host:   fmt.Sprintf("%s:8081", s.Hostname()),
 		Path:   path,
 	}
 	return u.String()

--- a/internal/http/html/cookies.go
+++ b/internal/http/html/cookies.go
@@ -13,7 +13,7 @@ func SetCookie(w http.ResponseWriter, name, value string, expiry *time.Time) {
 		Value:    value,
 		HttpOnly: true,
 		Path:     "/",
-		Secure:   true,
+		Secure:   false,
 		SameSite: http.SameSiteLaxMode,
 	}
 

--- a/internal/sql/sql.go
+++ b/internal/sql/sql.go
@@ -110,11 +110,12 @@ func Error(err error) error {
 
 func NoRowsInResultError(err error) bool {
 	for {
+		if err.Error() == "no rows in result set" {
+			return true
+		}
 		err = errors.Unwrap(err)
 		if err == nil {
 			return false
-		} else if err.Error() == "no rows in result set" {
-			return true
 		}
 	}
 }

--- a/internal/sql/sql.go
+++ b/internal/sql/sql.go
@@ -91,6 +91,7 @@ func TimestamptzPtr(t *time.Time) pgtype.Timestamptz {
 }
 
 func Error(err error) error {
+
 	var pgErr *pgconn.PgError
 	switch {
 	case NoRowsInResultError(err):
@@ -109,6 +110,9 @@ func Error(err error) error {
 }
 
 func NoRowsInResultError(err error) bool {
+	if err == nil {
+		return false
+	}
 	for {
 		if err.Error() == "no rows in result set" {
 			return true

--- a/internal/sql/sql_test.go
+++ b/internal/sql/sql_test.go
@@ -35,6 +35,7 @@ func TestSqlErrorHandling(t *testing.T) {
 		{"Expect handling of PG 23505", samplePgErr2, internal.ErrResourceAlreadyExists},
 		{"Expect raw return of other PG codes", samplePgErr3, samplePgErr3},
 		{"Expect raw return for any other error", internal.ErrAccessNotPermitted, internal.ErrAccessNotPermitted},
+		{"Expect nil should return nil", nil, nil},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/sql/sql_test.go
+++ b/internal/sql/sql_test.go
@@ -1,0 +1,45 @@
+package sql_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/assert"
+	"github.com/tofutf/tofutf/internal"
+	"github.com/tofutf/tofutf/internal/sql"
+)
+
+var samplePgErr1 = &pgconn.PgError{
+	Code: "23503",
+}
+var samplePgErr2 = &pgconn.PgError{
+	Code: "23505",
+}
+
+var samplePgErr3 = &pgconn.PgError{
+	Code: "23599",
+}
+
+func TestSqlErrorHandling(t *testing.T) {
+
+	tests := []struct {
+		name string
+		err  error
+		want error
+	}{
+		{"Expect no rows in result set without wrapping", errors.New("no rows in result set"), internal.ErrResourceNotFound},
+		{"Expect no rows in result set with wrapping", fmt.Errorf("something else: %w", errors.New("no rows in result set")), internal.ErrResourceNotFound},
+		{"Expect handling of PG 23503", samplePgErr1, &internal.ForeignKeyError{PgError: samplePgErr1}},
+		{"Expect handling of PG 23505", samplePgErr2, internal.ErrResourceAlreadyExists},
+		{"Expect raw return of other PG codes", samplePgErr3, samplePgErr3},
+		{"Expect raw return for any other error", internal.ErrAccessNotPermitted, internal.ErrAccessNotPermitted},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := sql.Error(tt.err)
+			assert.Equal(t, tt.want, err)
+		})
+	}
+}

--- a/internal/user/db.go
+++ b/internal/user/db.go
@@ -122,6 +122,7 @@ func (db *pgdb) getUser(ctx context.Context, spec UserSpec) (*User, error) {
 			return dbresult(result).toUser(), nil
 		} else if spec.Username != nil {
 			result, err := q.FindUserByUsername(ctx, sql.String(*spec.Username))
+			db.Logger.Debug("Find by username: %s %s", *spec.Username, err)
 			if err != nil {
 				return nil, sql.Error(err)
 			}

--- a/internal/user/service.go
+++ b/internal/user/service.go
@@ -100,14 +100,16 @@ func NewService(opts Options) *Service {
 	// Register with auth middleware the user token kind and a means of
 	// retrieving user corresponding to token.
 	opts.TokensService.RegisterKind(UserTokenKind, func(ctx context.Context, tokenID string) (internal.Subject, error) {
+		svc.logger.Debug("Register Kind")
 		return svc.GetUser(ctx, UserSpec{AuthenticationTokenID: internal.String(tokenID)})
 
 	})
 	// Register with auth middleware the ability to get or create a user given a
 	// username.
 	opts.TokensService.RegisterUISubjectGetterOrCreator(func(ctx context.Context, username string) (internal.Subject, error) {
+
 		user, err := svc.GetUser(ctx, UserSpec{Username: &username})
-		if err == internal.ErrResourceNotFound {
+		if errors.Is(err, internal.ErrResourceNotFound) {
 			user, err = svc.Create(ctx, username)
 		}
 		return user, err


### PR DESCRIPTION
Experienced issues with "auto" user registration through OIDC provider.

Database lookup for the username after a first time login would result in a system error.

Expectation is that the database layer should notify that there was an `ErrResourceNotFound` when seeing a `no rows in result set` error at DB level, triggering the creation of the user in the DB.

However, the current code doesn't handle the case where the error isn't wrapped, hence returning the raw DB error that the business layer doesn't know how to handle.