### PR TITLE
fix: Correct SQL handling of unwrapped errors

### DIFF
--- a/internal/sql/sql.go
+++ b/internal/sql/sql.go
@@ -91,6 +91,7 @@ func TimestamptzPtr(t *time.Time) pgtype.Timestamptz {
 }
 
 func Error(err error) error {
+
 	var pgErr *pgconn.PgError
 	switch {
 	case NoRowsInResultError(err):
@@ -109,12 +110,16 @@ func Error(err error) error {
 }
 
 func NoRowsInResultError(err error) bool {
+	if err == nil {
+		return false
+	}
 	for {
+		if err.Error() == "no rows in result set" {
+			return true
+		}
 		err = errors.Unwrap(err)
 		if err == nil {
 			return false
-		} else if err.Error() == "no rows in result set" {
-			return true
 		}
 	}
 }

--- a/internal/sql/sql_test.go
+++ b/internal/sql/sql_test.go
@@ -1,0 +1,46 @@
+package sql_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/assert"
+	"github.com/tofutf/tofutf/internal"
+	"github.com/tofutf/tofutf/internal/sql"
+)
+
+var samplePgErr1 = &pgconn.PgError{
+	Code: "23503",
+}
+var samplePgErr2 = &pgconn.PgError{
+	Code: "23505",
+}
+
+var samplePgErr3 = &pgconn.PgError{
+	Code: "23599",
+}
+
+func TestSqlErrorHandling(t *testing.T) {
+
+	tests := []struct {
+		name string
+		err  error
+		want error
+	}{
+		{"Expect no rows in result set without wrapping", errors.New("no rows in result set"), internal.ErrResourceNotFound},
+		{"Expect no rows in result set with wrapping", fmt.Errorf("something else: %w", errors.New("no rows in result set")), internal.ErrResourceNotFound},
+		{"Expect handling of PG 23503", samplePgErr1, &internal.ForeignKeyError{PgError: samplePgErr1}},
+		{"Expect handling of PG 23505", samplePgErr2, internal.ErrResourceAlreadyExists},
+		{"Expect raw return of other PG codes", samplePgErr3, samplePgErr3},
+		{"Expect raw return for any other error", internal.ErrAccessNotPermitted, internal.ErrAccessNotPermitted},
+		{"Expect nil should return nil", nil, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := sql.Error(tt.err)
+			assert.Equal(t, tt.want, err)
+		})
+	}
+}


### PR DESCRIPTION
Experienced issues with "auto" user registration through OIDC provider.

Database lookup for the username after a first time login would result in a system error.

Expectation is that the database layer should notify that there was an `ErrResourceNotFound` when seeing a `no rows in result set` error at DB level, triggering the creation of the user in the DB.

However, the current code doesn't handle the case where the error isn't wrapped, hence returning the raw DB error that the business layer doesn't know how to handle.